### PR TITLE
Asset changes

### DIFF
--- a/packages/contracts/README.md
+++ b/packages/contracts/README.md
@@ -35,13 +35,12 @@ contract NativeHashi721Example is NativeHashi721 {
   constructor(
     uint32 selfDomain,
     address connext,
-    address dummyTransactingAssetId,
     string memory name,
     string memory symbol,
     uint256 startTokenId,
     uint256 endTokenId,
     string memory baseTokenURI
-  ) NativeHashi721(selfDomain, connext, dummyTransactingAssetId, name, symbol) {
+  ) NativeHashi721(selfDomain, connext, name, symbol) {
     _startTokenId = startTokenId;
     _endTokenId = endTokenId;
     _baseTokenURI = baseTokenURI;
@@ -76,10 +75,6 @@ See documentation for variables required to deploy to other chains
 #### connext
 
 => The connext handler address of the network you deploy
-
-#### dummyTransactionAssetId
-
-=> The test ERC20 token address of the network you deploy
 
 You can find the each variables from
 https://docs.nfthashi.com/developer-guide/informations

--- a/packages/contracts/contracts/Hashi721Bridge.sol
+++ b/packages/contracts/contracts/Hashi721Bridge.sol
@@ -25,10 +25,9 @@ contract Hashi721Bridge is ERC165Upgradeable, HashiConnextAdapter {
   function initialize(
     uint32 selfDomain,
     address connext,
-    address dummyTransactingAssetId,
     address nftImplementation
   ) public initializer {
-    __Hashi721Bridge_init(selfDomain, connext, dummyTransactingAssetId, nftImplementation);
+    __Hashi721Bridge_init(selfDomain, connext, nftImplementation);
   }
 
   function setIsAllowListRequired(bool isRequired) public onlyOwner {
@@ -127,11 +126,10 @@ contract Hashi721Bridge is ERC165Upgradeable, HashiConnextAdapter {
   function __Hashi721Bridge_init(
     uint32 selfDomain,
     address connext,
-    address dummyTransactingAssetId,
     address nftImplementation
   ) internal onlyInitializing {
     __Ownable_init_unchained();
-    __HashiConnextAdapter_init_unchained(selfDomain, connext, dummyTransactingAssetId);
+    __HashiConnextAdapter_init_unchained(selfDomain, connext);
     __Hashi721Bridge_init_unchained(nftImplementation);
   }
 

--- a/packages/contracts/contracts/HashiConnextAdapter.sol
+++ b/packages/contracts/contracts/HashiConnextAdapter.sol
@@ -15,13 +15,11 @@ contract HashiConnextAdapter is OwnableUpgradeable, ERC165Upgradeable {
 
   address private _connext;
   address private _executor;
-  address private _transactingAssetId;
   uint32 private _selfDomain;
 
   event BridgeSet(uint32 domain, address bridgeContract);
   event ConnextSet(address connextContract);
   event SelfDomainSet(uint32 selfDomain);
-  event TransactingAssetIdSet(address transactingAssetId);
 
   modifier onlyExecutor() {
     require(msg.sender == _executor, "HashiConnextAdapter: sender invalid");
@@ -48,11 +46,6 @@ contract HashiConnextAdapter is OwnableUpgradeable, ERC165Upgradeable {
     emit SelfDomainSet(selfDomain);
   }
 
-  function setTransactingAssetId(address transactingAssetId) public onlyOwner {
-    _transactingAssetId = transactingAssetId;
-    emit TransactingAssetIdSet(transactingAssetId);
-  }
-
   function getBridgeContract(uint32 domain) public view returns (address) {
     return _bridgeContracts[domain];
   }
@@ -69,30 +62,17 @@ contract HashiConnextAdapter is OwnableUpgradeable, ERC165Upgradeable {
     return _selfDomain;
   }
 
-  function getTransactingAssetId() public view returns (address) {
-    return _transactingAssetId;
-  }
-
   // solhint-disable-next-line func-name-mixedcase
-  function __HashiConnextAdapter_init(
-    uint32 selfDomain,
-    address connext,
-    address transactingAssetId
-  ) internal onlyInitializing {
+  function __HashiConnextAdapter_init(uint32 selfDomain, address connext) internal onlyInitializing {
     __Ownable_init_unchained();
-    __HashiConnextAdapter_init_unchained(selfDomain, connext, transactingAssetId);
+    __HashiConnextAdapter_init_unchained(selfDomain, connext);
   }
 
   // solhint-disable-next-line func-name-mixedcase
-  function __HashiConnextAdapter_init_unchained(
-    uint32 selfDomain,
-    address connext,
-    address transactingAssetId
-  ) internal onlyInitializing {
+  function __HashiConnextAdapter_init_unchained(uint32 selfDomain, address connext) internal onlyInitializing {
     _selfDomain = selfDomain;
     _connext = connext;
     _executor = address(IConnextHandler(_connext).executor());
-    _transactingAssetId = transactingAssetId;
   }
 
   function _xcall(uint32 destinationDomain, bytes memory callData) internal {
@@ -112,7 +92,7 @@ contract HashiConnextAdapter is OwnableUpgradeable, ERC165Upgradeable {
       relayerFee: 0,
       slippageTol: 9995
     });
-    XCallArgs memory xcallArgs = XCallArgs({params: callParams, transactingAssetId: _transactingAssetId, amount: 0});
+    XCallArgs memory xcallArgs = XCallArgs({params: callParams, transactingAssetId: address(0), amount: 0});
     IConnextHandler(_connext).xcall(xcallArgs);
   }
 }

--- a/packages/contracts/contracts/NativeHashi721.sol
+++ b/packages/contracts/contracts/NativeHashi721.sol
@@ -12,21 +12,19 @@ contract NativeHashi721 is Initializable, ERC165Upgradeable, INativeHashi721, Ha
   constructor(
     uint32 selfDomain,
     address connext,
-    address dummyTransactingAssetId,
     string memory name,
     string memory symbol
   ) {
-    initialize(selfDomain, connext, dummyTransactingAssetId, name, symbol);
+    initialize(selfDomain, connext, name, symbol);
   }
 
   function initialize(
     uint32 selfDomain,
     address connext,
-    address dummyTransactingAssetId,
     string memory name,
     string memory symbol
   ) public initializer {
-    __HashiConnextAdapter_init(selfDomain, connext, dummyTransactingAssetId);
+    __HashiConnextAdapter_init(selfDomain, connext);
     __ERC721_init_unchained(name, symbol);
   }
 

--- a/packages/contracts/contracts/__experimental/XNFTTrader.sol
+++ b/packages/contracts/contracts/__experimental/XNFTTrader.sol
@@ -9,11 +9,7 @@ contract XNFTTrader is HashiConnextAdapter {
   MockMarket private _mockMarket;
 
   constructor(Hashi721Bridge hashi721Bridge, MockMarket mockMarket) {
-    __HashiConnextAdapter_init_unchained(
-      hashi721Bridge.getSelfDomain(),
-      hashi721Bridge.getConnext(),
-      hashi721Bridge.getTransactingAssetId()
-    );
+    __HashiConnextAdapter_init_unchained(hashi721Bridge.getSelfDomain(), hashi721Bridge.getConnext());
     _hashi721Bridge = hashi721Bridge;
     _mockMarket = mockMarket;
   }

--- a/packages/contracts/contracts/__mock/MockHashiConnextAdapter.sol
+++ b/packages/contracts/contracts/__mock/MockHashiConnextAdapter.sol
@@ -4,20 +4,12 @@ pragma solidity ^0.8.0;
 import "../HashiConnextAdapter.sol";
 
 contract MockHashiConnextAdapter is HashiConnextAdapter {
-  constructor(
-    uint32 selfDomain,
-    address connext,
-    address transactingAssetId
-  ) {
-    initialize(selfDomain, connext, transactingAssetId);
+  constructor(uint32 selfDomain, address connext) {
+    initialize(selfDomain, connext);
   }
 
-  function initialize(
-    uint32 selfDomain,
-    address connext,
-    address transactingAssetId
-  ) public initializer {
-    __HashiConnextAdapter_init(selfDomain, connext, transactingAssetId);
+  function initialize(uint32 selfDomain, address connext) public initializer {
+    __HashiConnextAdapter_init(selfDomain, connext);
   }
 
   // solhint-disable-next-line no-empty-blocks

--- a/packages/contracts/contracts/examples/NativeHashi721Example.sol
+++ b/packages/contracts/contracts/examples/NativeHashi721Example.sol
@@ -13,13 +13,12 @@ contract NativeHashi721Example is NativeHashi721 {
   constructor(
     uint32 selfDomain,
     address connext,
-    address dummyTransactingAssetId,
     string memory name,
     string memory symbol,
     uint256 startTokenId,
     uint256 endTokenId,
     string memory baseTokenURI
-  ) NativeHashi721(selfDomain, connext, dummyTransactingAssetId, name, symbol) {
+  ) NativeHashi721(selfDomain, connext, name, symbol) {
     _startTokenId = startTokenId;
     _endTokenId = endTokenId;
     _baseTokenURI = baseTokenURI;

--- a/packages/contracts/tasks/__experimental/deploy-x-nft-trader.ts
+++ b/packages/contracts/tasks/__experimental/deploy-x-nft-trader.ts
@@ -12,11 +12,11 @@ task("experimental-deploy-x-nft-trader", "experimental deploy cross nft trader")
     }
 
     const { domainId: selfDomainNum, contracts } = networks[name];
-    const { connext, testToken: dummyTransactingAssetId } = contracts;
+    const { connext } = contracts;
     const selfDomain = selfDomainNum.toString();
 
     const nftImplementation = await run("cmd-deploy-implementation");
-    const bridge = await run("cmd-deploy-bridge", { selfDomain, connext, dummyTransactingAssetId, nftImplementation });
+    const bridge = await run("cmd-deploy-bridge", { selfDomain, connext, nftImplementation });
 
     const MockMarket = await ethers.getContractFactory("MockMarket");
     const mockMarket = await MockMarket.deploy();

--- a/packages/contracts/tasks/cmd/deploy-bridge.ts
+++ b/packages/contracts/tasks/cmd/deploy-bridge.ts
@@ -3,15 +3,13 @@ import { task } from "hardhat/config";
 task("cmd-deploy-bridge", "cmd deploy bridge")
   .addParam("selfDomain", "self domain")
   .addParam("connext", "connext")
-  .addParam("dummyTransactingAssetId", "dummy transacting asset id")
   .addParam("wrappedNftImplementation", "nft implementation")
   .setAction(
-    async ({ selfDomain, connext, dummyTransactingAssetId, wrappedNftImplementation }, { ethers, upgrades }) => {
+    async ({ selfDomain, connext, wrappedNftImplementation }, { ethers, upgrades }) => {
       const Hashi721Bridge = await ethers.getContractFactory("Hashi721Bridge");
       const hashi721Bridge = await upgrades.deployProxy(Hashi721Bridge, [
         selfDomain,
         connext,
-        dummyTransactingAssetId,
         wrappedNftImplementation,
       ]);
       await hashi721Bridge.deployed();

--- a/packages/contracts/tasks/integration/deploy.ts
+++ b/packages/contracts/tasks/integration/deploy.ts
@@ -14,13 +14,12 @@ task("integration-deploy", "integration deploy")
       return;
     }
     const { domainId: selfDomainNum, contracts } = networks[name];
-    const { connext, testToken: dummyTransactingAssetId } = contracts;
+    const { connext } = contracts;
     const selfDomain = selfDomainNum.toString();
     const wrappedNftImplementation = await run("cmd-deploy-wrapped-nft-impl");
     const bridge = await run("cmd-deploy-bridge", {
       selfDomain,
       connext,
-      dummyTransactingAssetId,
       wrappedNftImplementation,
     });
     networks[name].contracts.wrappedNftImplementation = wrappedNftImplementation;

--- a/packages/contracts/test/integration/Bridge.ts
+++ b/packages/contracts/test/integration/Bridge.ts
@@ -20,7 +20,6 @@ describe("Integration Test for Bridge", function () {
 
     const selfDomain = "1111";
     const connextHandlerAddress = networks.rinkeby.contracts.connext;
-    const dummyTransactingAssetId = networks.rinkeby.contracts.testToken;
     const baseTokenURL = "http://localhost:3000/";
 
     const Hashi721Bridge = await ethers.getContractFactory("Hashi721Bridge");
@@ -28,7 +27,6 @@ describe("Integration Test for Bridge", function () {
     await hashi721Bridge.initialize(
       selfDomain,
       connextHandlerAddress,
-      dummyTransactingAssetId,
       wrappedHashi721.address
     );
 

--- a/packages/contracts/test/unit/Hashi721Bridge.ts
+++ b/packages/contracts/test/unit/Hashi721Bridge.ts
@@ -26,7 +26,6 @@ describe("Unit Test for Hashi721Bridge", function () {
   const baseTokenURL = "http://localhost:3000/";
 
   const selfDomain = "0";
-  const dummyTransactingAssetId = ADDRESS_1;
 
   beforeEach(async function () {
     [signer, malicious] = await ethers.getSigners();
@@ -46,7 +45,6 @@ describe("Unit Test for Hashi721Bridge", function () {
     await hashi721Bridge.initialize(
       selfDomain,
       mockConnextHandler.address,
-      dummyTransactingAssetId,
       wrappedHashi721.address
     );
 

--- a/packages/contracts/test/unit/HashiConnextAdapter.ts
+++ b/packages/contracts/test/unit/HashiConnextAdapter.ts
@@ -17,8 +17,6 @@ describe("Unit Test for HashiConnextAdapter", function () {
   const opponentDomain = 1;
   const opponentContract = ADDRESS_1;
 
-  const dummyTransactingAssetId = ADDRESS_1;
-
   beforeEach(async function () {
     [, malicious] = await ethers.getSigners();
     const MockConnextHandler = await ethers.getContractFactory("MockConnextHandler");
@@ -32,7 +30,6 @@ describe("Unit Test for HashiConnextAdapter", function () {
     mockHashiConnextAdapter = await MockHashiConnextAdapter.deploy(
       selfDomain,
       mockConnextHandler.address,
-      dummyTransactingAssetId
     );
   });
 
@@ -52,11 +49,7 @@ describe("Unit Test for HashiConnextAdapter", function () {
   it("getSelfDomain", async function () {
     expect(await mockHashiConnextAdapter.getSelfDomain()).to.equal(selfDomain);
   });
-
-  it("getTransactingAssetId", async function () {
-    expect(await mockHashiConnextAdapter.getTransactingAssetId()).to.equal(dummyTransactingAssetId);
-  });
-
+  
   it("setBridgeContract", async function () {
     expect(await mockHashiConnextAdapter.getBridgeContract(opponentDomain)).to.equal(NULL_ADDRESS);
     await expect(mockHashiConnextAdapter.setBridgeContract(opponentDomain, opponentContract))

--- a/packages/contracts/test/unit/NativeHashi721.ts
+++ b/packages/contracts/test/unit/NativeHashi721.ts
@@ -15,7 +15,6 @@ describe("Unit Test for NativeHashi721", function () {
   const selfDomain = "0";
   const opponentDomain = "1";
   const opponentContract = ADDRESS_1;
-  const dummyTransactingAssetId = ADDRESS_1;
   const name = "name";
   const symbol = "symbol";
 
@@ -33,7 +32,6 @@ describe("Unit Test for NativeHashi721", function () {
     nativeHashi721 = await NativeHashi721.deploy(
       selfDomain,
       mockConnextHandler.address,
-      dummyTransactingAssetId,
       name,
       symbol
     );

--- a/packages/contracts/test/unit/examples/NativeHashi721Example.ts
+++ b/packages/contracts/test/unit/examples/NativeHashi721Example.ts
@@ -13,7 +13,6 @@ describe("Unit Test for NativeHashi721Example", function () {
   const selfDomain = "0";
   const opponentDomain = "1";
   const opponentContract = ADDRESS_1;
-  const dummyTransactingAssetId = ADDRESS_1;
   const name = "name";
   const symbol = "symbol";
   const startTokenId = "0";
@@ -35,7 +34,6 @@ describe("Unit Test for NativeHashi721Example", function () {
     nativeHashi721Example = await NativeHashi721Example.deploy(
       selfDomain,
       mockConnextHandler.address,
-      dummyTransactingAssetId,
       name,
       symbol,
       startTokenId,


### PR DESCRIPTION
Changes to use Zero Address instead of dummyTransactingAsset. The Zero Address can  be used as the default asset in cases where `xcall` does not send any ERC20 amount.